### PR TITLE
Add CodeLens for pixi tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,10 @@
       {
         "command": "pixi-vscode.activateEnvironmentTerminal",
         "title": "Pixi: Activate Environment in new Terminal"
+      },
+      {
+        "command": "pixi-vscode.runTask",
+        "title": "Pixi: Run Task"
       }
     ],
     "menus": {

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -34,7 +34,9 @@ export enum PixiCommand {
 	install = "install",
 	add = "add",
 	remove = "remove",
-	list = "list",
+        list = "list",
 
-	addChannel = "project channel add",
+        addChannel = "project channel add",
+
+        run = "run",
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import { Pixi } from "./environmentManagers/pixi";
 import { PixiExtensionService } from "./extensionServices/pixi-extensionservice";
 import { PypiService } from "./pypi/pypi-service";
 import { PypiClient } from "./pypi/pypi-client";
+import { PixiTaskCodeLensProvider } from "./taskCodeLensProvider";
 const Cache = require("vscode-cache");
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
@@ -25,7 +26,14 @@ export function activate(context: vscode.ExtensionContext) {
 
 	context.subscriptions.push(disposable);
 
-	const pxe = new PixiExtensionService(cache, pypiService);
+       const pxe = new PixiExtensionService(cache, pypiService);
+
+        context.subscriptions.push(
+                vscode.languages.registerCodeLensProvider(
+                        { pattern: "**/pixi.toml" },
+                        new PixiTaskCodeLensProvider()
+                )
+        );
 
 	context.subscriptions.push(
 		vscode.commands.registerCommand(
@@ -78,14 +86,23 @@ export function activate(context: vscode.ExtensionContext) {
 		)
 	);
 
-	context.subscriptions.push(
-		vscode.commands.registerCommand(
-			"pixi-vscode.activateEnvironmentTerminal",
-			async (uri: vscode.Uri) => {
-				await pxe.activateEnvironmentTerminal(uri);
-			}
-		)
-	);
+        context.subscriptions.push(
+                vscode.commands.registerCommand(
+                        "pixi-vscode.activateEnvironmentTerminal",
+                        async (uri: vscode.Uri) => {
+                                await pxe.activateEnvironmentTerminal(uri);
+                        }
+                )
+        );
+
+        context.subscriptions.push(
+                vscode.commands.registerCommand(
+                        "pixi-vscode.runTask",
+                        async (uri: vscode.Uri, task: string) => {
+                                await pxe.runTask(uri, task);
+                        }
+                )
+        );
 }
 
 // This method is called when your extension is deactivated

--- a/src/extensionServices/pixi-extensionservice.ts
+++ b/src/extensionServices/pixi-extensionservice.ts
@@ -11,6 +11,7 @@ import {
 } from "@vscode/python-extension";
 import { VSCodeExtensionService } from "./vscode-service";
 import { PypiClient, PypiService } from "../pypi";
+import { PixiCommand } from "../enums";
 
 // Calls to this class are only made from src/extension.ts
 export class PixiExtensionService {
@@ -257,7 +258,7 @@ export class PixiExtensionService {
 			});
 	}
 
-	async activateEnvironmentTerminal(uri: vscode.Uri) {
+        async activateEnvironmentTerminal(uri: vscode.Uri) {
 		if (await this.vse.isEmptyWorkspace()) {
 			notify.error("No workspace folders open");
 			return;
@@ -287,11 +288,17 @@ export class PixiExtensionService {
 			return;
 		}
 
-		const cmd = `pixi shell -e ${env.name} --manifest-path ${manifestPath}`;
-		console.log(cmd);
-		// run "pixi shell -e $env" command
-		this.vse.openTerminalAndRunCommand(cmd, `Pixi: ${env.name}`, true);
-	}
+                const cmd = `pixi shell -e ${env.name} --manifest-path ${manifestPath}`;
+                console.log(cmd);
+                // run "pixi shell -e $env" command
+                this.vse.openTerminalAndRunCommand(cmd, `Pixi: ${env.name}`, true);
+        }
+
+        async runTask(manifestUri: vscode.Uri, task: string) {
+                const manifestPath = manifestUri.fsPath;
+                const args = [PixiCommand.run, task, "--manifest-path", manifestPath];
+                this.vse.runPixiCommand(args);
+        }
 
 	/**
 	 * Get the Pixi project directory

--- a/src/taskCodeLensProvider.ts
+++ b/src/taskCodeLensProvider.ts
@@ -1,40 +1,40 @@
 import * as vscode from "vscode";
 
 export class PixiTaskCodeLensProvider implements vscode.CodeLensProvider {
-    public provideCodeLenses(document: vscode.TextDocument, token: vscode.CancellationToken): vscode.ProviderResult<vscode.CodeLens[]> {
-        if (!document.fileName.endsWith("pixi.toml")) {
-            return [];
-        }
-        const lenses: vscode.CodeLens[] = [];
-        let inTasks = false;
-        for (let i = 0; i < document.lineCount; i++) {
-            const line = document.lineAt(i);
-            const text = line.text.trim();
-            if (text.startsWith("[tasks]")) {
-                inTasks = true;
-                continue;
-            }
-            if (inTasks && text.startsWith("[")) {
-                break;
-            }
-            if (!inTasks) {
-                continue;
-            }
-            if (text === "" || text.startsWith("#")) {
-                continue;
-            }
-            const match = /^([A-Za-z0-9_-]+)\s*=/.exec(text);
-            if (match) {
-                const taskName = match[1];
-                const range = new vscode.Range(i, 0, i, line.text.length);
-                const cmd: vscode.Command = {
-                    title: `Run ${taskName}`,
-                    command: "pixi-vscode.runTask",
-                    arguments: [document.uri, taskName]
-                };
-                lenses.push(new vscode.CodeLens(range, cmd));
-            }
-        }
-        return lenses;
-    }
+	public provideCodeLenses(document: vscode.TextDocument, token: vscode.CancellationToken): vscode.ProviderResult<vscode.CodeLens[]> {
+		if (!document.fileName.endsWith("pixi.toml")) {
+			return [];
+		}
+		const lenses: vscode.CodeLens[] = [];
+		let inTasks = false;
+		for (let i = 0; i < document.lineCount; i++) {
+			const line = document.lineAt(i);
+			const text = line.text.trim();
+			if (text.startsWith("[tasks]")) {
+			    inTasks = true;
+			    continue;
+			}
+			if (inTasks && text.startsWith("[")) {
+			    break;
+			}
+			if (!inTasks) {
+			    continue;
+			}
+			if (text === "" || text.startsWith("#")) {
+			    continue;
+			}
+			const match = /^([A-Za-z0-9_-]+)\s*=/.exec(text);
+			if (match) {
+			    const taskName = match[1];
+			    const range = new vscode.Range(i, 0, i, line.text.length);
+			    const cmd: vscode.Command = {
+			        title: `Run ${taskName}`,
+			        command: "pixi-vscode.runTask",
+			        arguments: [document.uri, taskName]
+			    };
+			    lenses.push(new vscode.CodeLens(range, cmd));
+			}
+		}
+		return lenses;
+	}
 }

--- a/src/taskCodeLensProvider.ts
+++ b/src/taskCodeLensProvider.ts
@@ -1,0 +1,40 @@
+import * as vscode from "vscode";
+
+export class PixiTaskCodeLensProvider implements vscode.CodeLensProvider {
+    public provideCodeLenses(document: vscode.TextDocument, token: vscode.CancellationToken): vscode.ProviderResult<vscode.CodeLens[]> {
+        if (!document.fileName.endsWith("pixi.toml")) {
+            return [];
+        }
+        const lenses: vscode.CodeLens[] = [];
+        let inTasks = false;
+        for (let i = 0; i < document.lineCount; i++) {
+            const line = document.lineAt(i);
+            const text = line.text.trim();
+            if (text.startsWith("[tasks]")) {
+                inTasks = true;
+                continue;
+            }
+            if (inTasks && text.startsWith("[")) {
+                break;
+            }
+            if (!inTasks) {
+                continue;
+            }
+            if (text === "" || text.startsWith("#")) {
+                continue;
+            }
+            const match = /^([A-Za-z0-9_-]+)\s*=/.exec(text);
+            if (match) {
+                const taskName = match[1];
+                const range = new vscode.Range(i, 0, i, line.text.length);
+                const cmd: vscode.Command = {
+                    title: `Run ${taskName}`,
+                    command: "pixi-vscode.runTask",
+                    arguments: [document.uri, taskName]
+                };
+                lenses.push(new vscode.CodeLens(range, cmd));
+            }
+        }
+        return lenses;
+    }
+}

--- a/src/test/suite/task-codelens-provider.test.ts
+++ b/src/test/suite/task-codelens-provider.test.ts
@@ -1,0 +1,20 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { PixiTaskCodeLensProvider } from '../../taskCodeLensProvider';
+
+suite('PixiTaskCodeLensProvider Tests', () => {
+        test('provideCodeLenses returns a CodeLens for each task', async () => {
+                const content = `[tasks]\ntest1 = "echo 1"\ntest2 = { cmd = "echo 2" }\n`;
+                const document = await vscode.workspace.openTextDocument({
+                        content,
+                        language: 'toml'
+                });
+                const provider = new PixiTaskCodeLensProvider();
+                const lenses = await provider.provideCodeLenses(document, new vscode.CancellationTokenSource().token);
+                assert.ok(Array.isArray(lenses));
+                assert.strictEqual((lenses as vscode.CodeLens[]).length, 2);
+                const [first] = lenses as vscode.CodeLens[];
+                assert.strictEqual(first.command?.command, 'pixi-vscode.runTask');
+                assert.strictEqual(first.command?.arguments?.[1], 'test1');
+        });
+});


### PR DESCRIPTION
## Summary
- add `run` command to enum
- implement a method to run a task via pixi
- introduce `PixiTaskCodeLensProvider` to show `Run` links in pixi.toml
- register CodeLens provider and new command
- expose command in package.json

## Testing
- `yarn run compile`
- `yarn test` *(fails: SIGSEGV)*

------
https://chatgpt.com/codex/tasks/task_e_6852b561072c832e9e5b61882e8a9239